### PR TITLE
don't allow skipping of missing libraries when testing verification

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -193,8 +193,9 @@ jobs:
       - run: python3 -m pip install -r requirements.txt
         name: Install requirements
 
-      - name: Install implementations
-        run: python3 install_implementations.py --install-type verification
+        run: |
+          python3 -m pip install setuptools
+          python3 install_implementations.py --install-type verification
 
       - run: python3 verify.py verification.json --test auto --processes 4 --skip-missing-libraries false
         name: Run verification test

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -193,6 +193,7 @@ jobs:
       - run: python3 -m pip install -r requirements.txt
         name: Install requirements
 
+      - name: Install implementations
         run: |
           python3 -m pip install setuptools
           python3 install_implementations.py --install-type verification

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Install implementations
         run: python3 install_implementations.py --install-type verification
 
-      - run: python3 verify.py verification.json --test auto --processes 4
+      - run: python3 verify.py verification.json --test auto --processes 4 --skip-missing-libraries false
         name: Run verification test
 
   build-and-push-website:

--- a/verify.py
+++ b/verify.py
@@ -119,11 +119,11 @@ def verify_examples(
                 else:
                     results[e.filename][i]["fail"].append(eg)
                     print(f"{process}{e.filename} {i} {eg} {red}\u2715{default}")
-            except ImportError as e:
+            except ImportError as err:
                 if skip_missing:
                     print(f"{process}{i} not installed")
                 else:
-                    raise e
+                    raise err
             except NotImplementedError:
                 results[e.filename][i]["not implemented"].append(eg)
                 print(f"{process}{e.filename} {i} {eg} {blue}\u2013{default}")

--- a/verify.py
+++ b/verify.py
@@ -24,6 +24,8 @@ parser.add_argument('--test', metavar="test", default=None,
                     help="Verify fewer elements.")
 parser.add_argument('--processes', metavar="processes", default=None,
                     help="The number of processes to run the verification on.")
+parser.add_argument('--skip-missing-libraries', default="true",
+                    help="Skip verification if library is not installed.")
 
 args = parser.parse_args()
 if args.destination is not None:
@@ -39,6 +41,7 @@ elif args.test == "auto":
         "serendipity", "taylor-hood", "vector-bubble-enriched-Lagrange", "enriched-galerkin"]
 else:
     test_elements = args.test.split(",")
+skip_missing = args.skip_missing_libraries == "true"
 
 categoriser = Categoriser()
 categoriser.load_references(os.path.join(settings.data_path, "references"))
@@ -116,8 +119,11 @@ def verify_examples(
                 else:
                     results[e.filename][i]["fail"].append(eg)
                     print(f"{process}{e.filename} {i} {eg} {red}\u2715{default}")
-            except ImportError:
-                print(f"{process}{i} not installed")
+            except ImportError as e:
+                if skip_missing:
+                    print(f"{process}{i} not installed")
+                else:
+                    raise e
             except NotImplementedError:
                 results[e.filename][i]["not implemented"].append(eg)
                 print(f"{process}{e.filename} {i} {eg} {blue}\u2013{default}")


### PR DESCRIPTION
This will cause CI to fail before libraries silently disappear in future if their install starts failing