### PR TITLE
wrap names in bibtex

### DIFF
--- a/defelement/markup.py
+++ b/defelement/markup.py
@@ -59,7 +59,7 @@ def format_names(names: typing.List[str], format: str) -> str:
         Formatted names
     """
     if format == "bibtex":
-        return " and ".join(names)
+        return ("\n" + " " * 17 + "and ").join(names)
     else:
         formatted_names = []
         for n in names:


### PR DESCRIPTION
To stop this being very wide:

![image](https://github.com/user-attachments/assets/c0d3f1f6-5ee5-4348-aa9d-50aa4bf77378)
